### PR TITLE
fix building of _reversed_padding_repeated_twice

### DIFF
--- a/escnn/nn/modules/conv/rd_convolution.py
+++ b/escnn/nn/modules/conv/rd_convolution.py
@@ -150,7 +150,7 @@ class _RdConv(EquivariantModule, ABC):
         padding_modes = {'zeros', 'reflect', 'replicate', 'circular'}
         if padding_mode not in padding_modes:
             raise ValueError("padding_mode must be one of [{}], but got padding_mode='{}'".format(padding_modes, padding_mode))
-        self._reversed_padding_repeated_twice = tuple(x for x in reversed(_padding) for _ in range(self.d))
+        self._reversed_padding_repeated_twice = tuple(sum(([x, x] for x in reversed(_padding)), []))
         
         if groups > 1:
             # Check the input and output classes can be split in `groups` groups, all equal to each other


### PR DESCRIPTION
Using a `padding_mode` other than `zeros` in `R3Conv` fails with:

```
RuntimeError: Padding length must be divisible by 2
```
This is because the current way `_reversed_padding_repeated_twice` is built is incorrect for d > 2. It repeats `_padding` d times, but at that point `_padding` is already d-dimensional, so for e.g. d = 3, `_reversed_padding_repeated_twice` becomes 9 dimensional, which is incorrect.

Signed-off-by: Guilherme Pires <guilherme.pires@alleninstitute.org>