### PR TITLE
Fix meshgrid warning related to indexing argument

### DIFF
--- a/escnn/nn/modules/basismanager/basisexpansion_blocks.py
+++ b/escnn/nn/modules/basismanager/basisexpansion_blocks.py
@@ -125,7 +125,7 @@ class BlocksBasisExpansion(torch.nn.Module, BasisManager):
                 setattr(self, 'out_indices_{}'.format(self._escape_pair(io_pair)), out_indices)
 
             else:
-                out_indices, in_indices = torch.meshgrid([_out_indices[io_pair[1]], _in_indices[io_pair[0]]])
+                out_indices, in_indices = torch.meshgrid([_out_indices[io_pair[1]], _in_indices[io_pair[0]]], indexing='ij')
                 in_indices = in_indices.reshape(-1)
                 out_indices = out_indices.reshape(-1)
                 

--- a/escnn/nn/modules/basismanager/basissampler_blocks.py
+++ b/escnn/nn/modules/basismanager/basissampler_blocks.py
@@ -382,7 +382,7 @@ class BlocksBasisSampler(torch.nn.Module, BasisManager):
                         in_indices[0]:in_indices[1],
                     ] = expanded.reshape(S, out_indices[2], in_indices[2])
                 else:
-                    out_indices, in_indices = torch.meshgrid([out_indices, in_indices])
+                    out_indices, in_indices = torch.meshgrid([out_indices, in_indices], indexing='ij')
                     in_indices = in_indices.reshape(-1)
                     out_indices = out_indices.reshape(-1)
                     _filter[

--- a/escnn/nn/modules/pooling/pointwise_avg_3d.py
+++ b/escnn/nn/modules/pooling/pointwise_avg_3d.py
@@ -188,7 +188,10 @@ class PointwiseAvgPoolAntialiased3D(EquivariantModule):
         # grid_x = torch.arange(filter_size).repeat(filter_size).view(filter_size, filter_size)
         # grid_y = grid_x.t()
         # grid = torch.stack([grid_x, grid_y], dim=-1)
-        grid_x, grid_y, grid_z = torch.meshgrid(*[torch.arange(filter_size)]*3)
+        grid_x, grid_y, grid_z = torch.meshgrid(
+                [torch.arange(filter_size)] * 3,
+                indexing='ij',
+        )
         grid = torch.stack([grid_x, grid_y, grid_z], dim=-1)
 
         mean = (filter_size - 1) / 2.


### PR DESCRIPTION
Torch is in the process of changing the default behavior of the `meshgrid()` function from `indexing='ij'` to `indexing='xy'`, for better compatibility with numpy.  In the meantime, using `meshgrid()` without specifying the indexing argument generates a warning.  This commit explicitly specifies the previous default for all uses of `meshgrid()` in the codebase.  This doesn't change any behavior, it just silences the warning and makes the code robust against future changes to the default value of this argument.

See pytorch/pytorch#50276 for more details.