### PR TITLE
Generalize MaskModule to support N-dimensional input

### DIFF
--- a/escnn/nn/modules/masking_module.py
+++ b/escnn/nn/modules/masking_module.py
@@ -3,6 +3,7 @@ from escnn.nn import GeometricTensor
 from escnn.nn import FieldType
 from .equivariant_module import EquivariantModule
 
+from itertools import product, repeat
 from typing import Tuple
 
 import torch
@@ -12,30 +13,44 @@ import math
 __all__ = ["MaskModule"]
 
 
-def build_mask(s, margin=2, dtype=torch.float32):
-    mask = torch.zeros(1, 1, s, s, dtype=dtype)
+def build_mask(
+        s,
+        *,
+        dim: int = 2,
+        margin: float = 2.0,
+        sigma: float = 2.0,
+        dtype=torch.float32,
+):
+    mask = torch.zeros(1, 1, *repeat(s, dim), dtype=dtype)
     c = (s-1) / 2
     t = (c - margin/100.*c)**2
     sig = 2.
-    for x in range(s):
-        for y in range(s):
-            r = (x - c) ** 2 + (y - c) ** 2
-            if r > t:
-                mask[..., x, y] = math.exp((t - r)/sig**2)
-            else:
-                mask[..., x, y] = 1.
+    for k in product(range(s), repeat=dim):
+        r = sum((x - c)**2 for x in k)
+        if r > t:
+            mask[(..., *k)] = math.exp((t - r) / sigma**2)
+        else:
+            mask[(..., *k)] = 1.
     return mask
 
 
 class MaskModule(EquivariantModule):
 
-    def __init__(self, in_type: FieldType, S: int, margin: float = 0.):
+    def __init__(
+            self,
+            in_type: FieldType,
+            S: int,
+            margin: float = 0.,
+            sigma: float = 2.,
+    ):
         r"""
         
-        Performs an element-wise multiplication of the input with a *mask* of shape ``S x S``.
+        Performs an element-wise multiplication of the input with a *mask* of shape :math:`S^n`, where :math:`n` is the
+        dimensionality of the underlying space.
         
-        The mask has value :math:`1` in all pixels with distance smaller than ``(S-1)/2 * (1 - margin)/100`` from the
-        center of the mask and :math:`0` elsewhere. Values change smoothly between the two regions.
+        The mask has value :math:`1` in all pixels with distance smaller than
+        :math:`\frac{S - 1}{2} \times \frac{1 - \mathrm{margin}}{100}` from the center of the mask and :math:`0`
+        elsewhere. Values change smoothly between the two regions.
         
         This operation is useful to remove from an input image or feature map all the part of the signal defined on the
         pixels which lay outside the circle inscribed in the grid.
@@ -43,24 +58,35 @@ class MaskModule(EquivariantModule):
         discarded when rotating an image. However, allowing a model to use this information might break the guaranteed
         equivariance as rotated and non-rotated inputs have different information content.
         
-        
         .. note::
-        
-            In order to perform the masking, the module expects an input with the same spatial dimensions as the mask.
-            Then, input tensors must have shape ``B x C x S x S``.
-        
+            The input tensors provided to this module must have the following dimensions: :math:`B \times C \times S^n`,
+            where :math:`B` is the minibatch dimension, :math:`C` is the fiber group dimension, and :math:`S^n` are the
+            Euclidean dimensions associated with the given input field type.  Each Euclidean dimension must be of size
+            :math:`S`.
+
+            For example, if :math:`S=10` and the group is defined over :math:`\mathbb{R}^2`, then the input tensors
+            should be of size :math:`B \times C \times 10 \times 10`.  If the group were defined over
+            :math:`\mathbb{R}^3` instead, then the input tensors should be of size
+            :math:`B \times C \times 10 \times 10 \times 10`.
         
         Args:
             in_type (FieldType): input field type
             S (int): the shape of the mask and the expected inputs
             margin (float, optional): margin around the mask in percentage with respect to the radius of the mask
-                                      (default ``0.``)
+            sigma (float, optional): how quickly masked pixels should approach 0.  This can be thought of a standard
+                deviation in units of pixels/voxels.  For example, the default value of 2 means that only 5% of the
+                original signal will remain 4 px into the masked region.
         
         """
         super(MaskModule, self).__init__()
 
+        dim = in_type.gspace.dimensionality
+
         self.margin = margin
-        self.mask = torch.nn.Parameter(build_mask(S, margin=margin), requires_grad=False)
+        self.mask = torch.nn.Parameter(
+                build_mask(S, dim=dim, margin=margin, sigma=sigma),
+                requires_grad=False,
+        )
 
         self.in_type = self.out_type = in_type
 

--- a/test/nn/test_mask.py
+++ b/test/nn/test_mask.py
@@ -1,0 +1,91 @@
+import unittest
+import torch
+
+from unittest import TestCase
+from escnn.gspaces import rot2dOnR2, rot3dOnR3
+from escnn.nn import FieldType, GeometricTensor, MaskModule
+
+class TestMask(TestCase):
+
+    def test_mask_module_r2(self):
+        gspace = rot2dOnR2()
+        in_type = FieldType(gspace, [gspace.trivial_repr])
+
+        # Use a very low standard deviation to make the transition between 
+        # masked/unmasked more dramatic.
+        mask = MaskModule(in_type, 5, margin=0, sigma=0.1)
+
+        x = GeometricTensor(
+                torch.ones(1, 1, 5, 5),
+                in_type,
+        )
+        y = mask(x)
+
+        unmasked_indices = [
+                (1, 1),
+                (1, 3),
+                (3, 1),
+                (3, 3),
+        ]
+        masked_indices = [
+                (0, 0),
+                (0, 4),
+                (4, 0),
+                (4, 4),
+        ]
+
+        assert y.type == in_type
+
+        for i,j in unmasked_indices:
+            self.assertGreater(y.tensor[0, 0, i, j], 1 - 1e5)
+        for i,j in masked_indices:
+            self.assertLess(y.tensor[0, 0, i, j], 1e-5)
+
+    def test_mask_module_r3(self):
+        gspace = rot3dOnR3()
+        in_type = FieldType(gspace, [gspace.trivial_repr])
+
+        # Use a very low standard deviation to make the transition between 
+        # masked/unmasked more dramatic.
+        mask = MaskModule(in_type, 5, margin=0, sigma=0.1)
+
+        x = GeometricTensor(
+                torch.ones(1, 1, 5, 5, 5),
+                in_type,
+        )
+        y = mask(x)
+
+        unmasked_indices = [
+                (1, 1, 1),
+                (1, 1, 3),
+                (1, 3, 1),
+                (1, 3, 3),
+                (3, 1, 1),
+                (3, 1, 3),
+                (3, 3, 1),
+                (3, 3, 3),
+        ]
+        masked_indices = [
+                (0, 0, 0),
+                (0, 0, 4),
+                (0, 4, 0),
+                (0, 4, 4),
+                (4, 0, 0),
+                (4, 0, 4),
+                (4, 4, 0),
+                (4, 4, 4),
+        ]
+
+        assert y.type == in_type
+
+        for i,j,k in unmasked_indices:
+            self.assertGreater(y.tensor[0, 0, i, j, k], 1 - 1e5)
+        for i,j,k in masked_indices:
+            self.assertLess(y.tensor[0, 0, i, j, k], 1e-5)
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+
+


### PR DESCRIPTION
This PR fixes #62.  I'd run into the same issue a few weeks ago, and now that I'm not the only one affected, I thought that it was worth taking some time to contribute a solution.

Some miscellaneous comments:

- I changed the signature of `build_mask()` in a way that's not strictly backwards compatible.  However, since this function is not documented, I think it's fair to say that it's not part of the public interface, and therefore doesn't need to maintain backwards compatibility.  
- The documentation states that "the mask has value 1 in all pixels with distance smaller than ... from the center of the mask and 0 elsewhere."  This isn't strictly true, because the values outside the mask decay exponentially and never actually reach 0.  Practically this is a minor distinction, but I mention it because it confused me a bit when I was first reading about this class.
- Is there a reason the mask goes to the effort to smoothly transition between 1 and 0?  If the idea is to remove the pixels in the corners of an image that would be lost anyways when the image is rotated, my first instinct would be to simply set any corner pixels to 0 and to leave any other pixels unaffected, with no smooth transition.  Again, though, I only mention this because it confused me at first and not because I think it makes a big difference in practice.