### PR TITLE
Fix typos

### DIFF
--- a/escnn/nn/modules/conv/r3convolution.py
+++ b/escnn/nn/modules/conv/r3convolution.py
@@ -50,7 +50,7 @@ class R3Conv(_RdConv):
         Specifically, let :math:`\rho_\text{in}: G \to \GL{\R^{c_\text{in}}}` and
         :math:`\rho_\text{out}: G \to \GL{\R^{c_\text{out}}}` be the representations specified by the input and output
         field types.
-        Then :class:`~escnn.nn.R2Conv` guarantees an equivariant mapping
+        Then :class:`~escnn.nn.R3Conv` guarantees an equivariant mapping
 
         .. math::
             \kappa \star [\mathcal{T}^\text{in}_{g,u} . f] = \mathcal{T}^\text{out}_{g,u} . [\kappa \star f] \qquad\qquad \forall g \in G, u \in \R^3
@@ -78,7 +78,7 @@ class R3Conv(_RdConv):
             convolution module.
 
         During training, in each forward pass the module expands the basis of G-steerable kernels with learned weights
-        before calling :func:`torch.nn.functional.conv2d`.
+        before calling :func:`torch.nn.functional.conv3d`.
         When :meth:`~torch.nn.Module.eval()` is called, the filter is built with the current trained weights and stored
         for future reuse such that no overhead of expanding the kernel remains.
 
@@ -145,10 +145,10 @@ class R3Conv(_RdConv):
 
             ~.weights (torch.Tensor): the learnable parameters which are used to expand the kernel
             ~.filter (torch.Tensor): the convolutional kernel obtained by expanding the parameters
-                                    in :attr:`~escnn.nn.R2Conv.weights`
+                                    in :attr:`~escnn.nn.R3Conv.weights`
             ~.bias (torch.Tensor): the learnable parameters which are used to expand the bias, if ``bias=True``
             ~.expanded_bias (torch.Tensor): the equivariant bias which is summed to the output, obtained by expanding
-                                    the parameters in :attr:`~escnn.nn.R2Conv.bias`
+                                    the parameters in :attr:`~escnn.nn.R3Conv.bias`
 
         """
 
@@ -340,7 +340,7 @@ class R3Conv(_RdConv):
 
     def export(self):
         r"""
-        Export this module to a normal PyTorch :class:`torch.nn.Conv2d` module and set to "eval" mode.
+        Export this module to a normal PyTorch :class:`torch.nn.Conv3d` module and set to "eval" mode.
 
         """
     

--- a/escnn/nn/modules/pooling/pointwise_max.py
+++ b/escnn/nn/modules/pooling/pointwise_max.py
@@ -171,7 +171,7 @@ class _PointwiseMaxPoolND(EquivariantModule):
         if self.d == 2:
             return torch.nn.MaxPool2d(self.kernel_size, self.stride, self.padding, self.dilation).eval()
         elif self.d == 3:
-            return torch.nn.MaxPool2d(self.kernel_size, self.stride, self.padding, self.dilation).eval()
+            return torch.nn.MaxPool3d(self.kernel_size, self.stride, self.padding, self.dilation).eval()
         else:
             raise NotImplementedError
 

--- a/test/group/test_disentangle_representation.py
+++ b/test/group/test_disentangle_representation.py
@@ -294,49 +294,49 @@ class TestDisentangleRepresentation(TestCase):
 
     def test_restrict_o2_flips(self):
         dg = O2(10)
-        repr = directsum(dg.irreps)
+        repr = directsum(dg.irreps())
         sg_id = (0., 1)
         self.check_disentangle(dg.restrict_representation(sg_id, repr))
 
     def test_restrict_o2_dihedral_even(self):
         dg = O2(10)
-        repr = directsum(dg.irreps)
+        repr = directsum(dg.irreps())
         sg_id = (0., 6)
         self.check_disentangle(dg.restrict_representation(sg_id, repr))
 
     def test_restrict_o2_dihedral_odd(self):
         dg = O2(10)
-        repr = directsum(dg.irreps)
+        repr = directsum(dg.irreps())
         sg_id = (0., 3)
         self.check_disentangle(dg.restrict_representation(sg_id, repr))
 
     def test_restrict_o2_so2(self):
         dg = O2(10)
-        repr = directsum(dg.irreps)
+        repr = directsum(dg.irreps())
         sg_id = (None, -1)
         self.check_disentangle(dg.restrict_representation(sg_id, repr))
         
     def test_restrict_o2_cyclic_even(self):
         dg = O2(10)
-        repr = directsum(dg.irreps)
+        repr = directsum(dg.irreps())
         sg_id = (None, 4)
         self.check_disentangle(dg.restrict_representation(sg_id, repr))
 
     def test_restrict_o2_cyclic_odd(self):
         dg = O2(10)
-        repr = directsum(dg.irreps)
+        repr = directsum(dg.irreps())
         sg_id = (None, 3)
         self.check_disentangle(dg.restrict_representation(sg_id, repr))
 
     def test_restrict_so2_cyclic_even(self):
         dg = SO2(10)
-        repr = directsum(dg.irreps)
+        repr = directsum(dg.irreps())
         sg_id = 8
         self.check_disentangle(dg.restrict_representation(sg_id, repr))
 
     def test_restrict_so2_cyclic_odd(self):
         dg = SO2(10)
-        repr = directsum(dg.irreps)
+        repr = directsum(dg.irreps())
         sg_id = 7
         self.check_disentangle(dg.restrict_representation(sg_id, repr))
 


### PR DESCRIPTION
Hi @Gabri95,

I collected some typos and bugs:
- BUG: typo in test, fixed by 4db45df0cbe73d6ff48d8d8031181d886531a3ae
  - run: `python -m unittest test/group/test_disentangle_representation.py`
  - raise `TypeError: 'method' object is not subscriptable` 
- BUG: typo in `export` in `PointwiseMaxPool3D`, fixed by 6ba2f9b996c4caf3e5df85c04619361b15f91a91
- DOC: typo in [`R3Conv`](https://quva-lab.github.io/escnn/api/escnn.nn.html#r3conv) docs, fixed by 90b40e7039c88761fb5ffd2529c0709cf42e8ae2