### PR TITLE
added leaky relu activation and tests

### DIFF
--- a/escnn/nn/modules/nonlinearities/leakyrelu.py
+++ b/escnn/nn/modules/nonlinearities/leakyrelu.py
@@ -1,0 +1,128 @@
+from typing import Any, List, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from escnn.gspaces import GSpace
+from escnn.nn import FieldType, GeometricTensor
+
+from ..equivariant_module import EquivariantModule
+
+__all__ = ["LeakyReLU"]
+
+
+class LeakyReLU(EquivariantModule):
+    def __init__(
+        self, in_type: FieldType, negative_slope: float = 0.01, inplace: bool = False
+    ):
+        r"""
+
+        Module that implements a pointwise LeakyReLU to every channel independently.
+        The input representation is preserved by this operation and, therefore, it equals the output
+        representation.
+
+        Only representations supporting pointwise non-linearities are accepted as input field type.
+
+        Args:
+            in_type (FieldType):  the input field type
+            negative_slope (float, optional): Controls the angle of the negative slope (which is used for negative input values). Default: 0.01
+            inplace (bool, optional): can optionally do the operation in-place. Default: ``False``
+
+        """
+
+        assert isinstance(in_type.gspace, GSpace)
+
+        super(LeakyReLU, self).__init__()
+
+        for r in in_type.representations:
+            assert (
+                "pointwise" in r.supported_nonlinearities
+            ), 'Error! Representation "{}" does not support "pointwise" non-linearity'.format(
+                r.name
+            )
+
+        self.space = in_type.gspace
+        self.in_type = in_type
+
+        # the representation in input is preserved
+        self.out_type = in_type
+
+        self._negative_slope = negative_slope
+        self._inplace = inplace
+
+    def forward(self, input: GeometricTensor) -> GeometricTensor:
+        r"""
+
+        Applies ReLU function on the input fields
+
+        Args:
+            input (GeometricTensor): the input feature map
+
+        Returns:
+            the resulting feature map after relu has been applied
+
+        """
+
+        assert (
+            input.type == self.in_type
+        ), "Error! the type of the input does not match the input type of this module"
+        return GeometricTensor(
+            F.leaky_relu(
+                input.tensor, negative_slope=self._negative_slope, inplace=self._inplace
+            ),
+            self.out_type,
+            input.coords,
+        )
+
+    def evaluate_output_shape(self, input_shape: Tuple[int, ...]) -> Tuple[int, ...]:
+        assert len(input_shape) >= 2
+        assert input_shape[1] == self.in_type.size
+
+        b, c = input_shape[:2]
+        spatial_shape = input_shape[2:]
+
+        return (b, self.out_type.size, *spatial_shape)
+
+    def check_equivariance(
+        self, atol: float = 1e-6, rtol: float = 1e-5
+    ) -> List[Tuple[Any, float]]:
+        c = self.in_type.size
+
+        x = torch.randn(3, c, 10, 10)
+
+        x = GeometricTensor(x, self.in_type)
+
+        errors = []
+
+        for el in self.space.testing_elements:
+            out1 = self(x).transform_fibers(el)
+            out2 = self(x.transform_fibers(el))
+
+            errs = (out1.tensor - out2.tensor).detach().numpy()
+            errs = np.abs(errs).reshape(-1)
+            print(el, errs.max(), errs.mean(), errs.var())
+
+            assert torch.allclose(
+                out1.tensor, out2.tensor, atol=atol, rtol=rtol
+            ), 'The error found during equivariance check with element "{}" is too high: max = {}, mean = {} var ={}'.format(
+                el, errs.max(), errs.mean(), errs.var()
+            )
+
+            errors.append((el, errs.mean()))
+
+        return errors
+
+    def extra_repr(self):
+        return "inplace={}, type={}".format(self._inplace, self.in_type)
+
+    def export(self):
+        r"""
+        Export this module to a normal PyTorch :class:`torch.nn.LeakyReLU` module and set to "eval" mode.
+
+        """
+
+        self.eval()
+
+        return torch.nn.LeakyReLU(
+            negative_slope=self._negative_slope, inplace=self._inplace
+        )

--- a/test/nn/test_fourier_leakyrelu.py
+++ b/test/nn/test_fourier_leakyrelu.py
@@ -1,0 +1,359 @@
+import unittest
+from collections import defaultdict
+from typing import Callable, Iterable, List
+from unittest import TestCase
+
+import numpy as np
+import torch
+from escnn.group import *
+from escnn.gspaces import *
+from escnn.nn import *
+
+
+def compute_energies(F, rho: Representation):
+    E = (F**2).mean(axis=1)
+    energies = defaultdict(float)
+
+    p = 0
+    for irr in rho.irreps:
+        irr = rho.group.irrep(*irr)
+
+        energies[irr.attributes["frequency"]] += E[p : p + irr.size].sum()
+
+        p += irr.size
+    return dict(energies)
+
+
+def _so3_sensing_sampling(m):
+    G = SO3(1)
+    for p in range(m):
+        cos_theta = (2 * p - m + 1) / (m - 1)
+        theta = np.arccos(cos_theta)
+        phi = 2 * np.pi * np.random.rand()
+        psi = 2 * np.pi * np.random.rand()
+
+        x = G.element(np.asarray([phi, theta, psi]), "ZYZ")
+
+        yield x
+
+
+def _so3_random_sampling(n):
+    G = SO3(1)
+    for _ in range(n):
+        theta = np.pi * np.random.rand()
+        phi = 2 * np.pi * np.random.rand()
+        psi = 2 * np.pi * np.random.rand()
+
+        x = G.element(np.asarray([phi, theta, psi]), "ZYZ")
+
+        yield x
+
+
+def _uniform_sampling(n, G: Group):
+    for _ in range(n):
+        yield G.sample()
+
+
+def _regular_sampling(n, G: Group):
+    for x in G.testing_elements(n):
+        yield x
+
+
+def _so3_platonic_sampling(solid):
+    G = SO3(1)
+    for x in G.grid(solid):
+        yield x
+
+
+def _so3_hopf_sampling(N):
+    G = SO3(1)
+    for x in G.grid("hopf", N=N):
+        yield x
+
+
+def _so3_thomson_cube_sampling(n):
+    G = SO3(1)
+    thomson = G.grid("thomson", n)
+    cube = G.grid("octa")
+
+    for c in cube:
+        for t in thomson:
+            yield c @ t
+
+
+def activation(activation: str):
+    if activation == "identity":
+        activation = lambda x: x
+    elif activation == "relu":
+        activation = lambda x: np.maximum(x, 0.0)
+    elif activation == "leakyrelu":
+        activation = (
+            lambda x: torch.nn.functional.leaky_relu(torch.tensor(x)).detach().numpy()
+        )  # TODO: unclear how to include negative slope parameter
+    elif activation == "sin":
+        activation = lambda x: np.sin(x)
+    elif activation == "elu":
+        activation = (
+            lambda x: torch.nn.functional.elu(torch.tensor(x)).detach().numpy()
+        )  # + 1.
+    else:
+        raise ValueError
+    return activation
+
+
+def preconditioning_so3(preconditioning: str):
+    if preconditioning == "sin":
+        return lambda sample: np.sqrt(np.sin(sample.to("ZYZ")[1]))
+    elif preconditioning == "tan":
+        return lambda sample: np.abs(np.cbrt(np.tan(sample.to("ZYZ")[1])))
+    elif preconditioning == "uniform":
+        return lambda sample: 1.0
+    else:
+        raise ValueError()
+
+
+def kernel_so3(L: int, kernel: str, **kwargs):
+    d = 0
+    for l in range(L + 1):
+        d += (2 * l + 1) ** 2
+
+    V = np.zeros((d, 1))
+
+    if kernel == "dirac":
+        p = 0
+        for l in range(L + 1):
+            d = 2 * l + 1
+            V[p : p + d**2, 0] = np.eye(d).reshape(-1) * d
+            p += d**2
+    elif kernel == "P":
+        assert "r" in kwargs
+        r = kwargs["r"]
+
+        p = 0
+        for l in range(L + 1):
+            d = 2 * l + 1
+            f = (1 - r) ** 2 * r**l / (1 + r) / d
+            V[p : p + d**2, 0] = np.eye(d).reshape(-1) * f * d
+            p += d**2
+    else:
+        raise ValueError
+
+    V /= np.linalg.norm(V.reshape(-1))
+    return V
+
+
+def check_reconstruction(
+    rho: Representation,
+    kernel: np.ndarray,
+    sampler: Iterable[GroupElement],
+    preconditioning: Callable[[GroupElement], float],
+    activation: Callable[[float], float],
+    regularization: float = 0.0,
+    samples: int = 200,
+):
+    G = rho.group
+    assert kernel.shape == (rho.size, 1)
+
+    def reconstruct(x, w, y, l=0.0):
+        A = w * x
+        # A = x
+        A_inv = np.linalg.inv(A.T @ A + l * np.eye(A.shape[1])) @ A.T
+        # A_inv = A.T
+        # A_inv = A_inv * w.T
+
+        return A_inv @ y
+
+    def build_sensing_matrix(samples: Iterable[GroupElement], preconditioning):
+        X = []
+        W = []
+        for x in samples:
+            X.append(kernel.T @ rho(x))
+            W.append(preconditioning(x))
+        N = len(X)
+
+        X = np.concatenate(X, axis=0) / np.sqrt(N)
+        assert X.shape == (N, rho.size)
+
+        W = np.array(W).reshape(N, 1)
+
+        return W, X
+
+    features = np.random.randn(rho.size, samples)
+    features /= np.linalg.norm(features, axis=0, keepdims=True)
+    features *= 3.0
+
+    energies = sorted(list(compute_energies(features, rho).items()))
+    energies = np.asarray([e for l, e in energies])
+    # print("Initial Energies: ", energies)
+
+    def evaluate_samples(samples, preconditioning, activation, l=0.0):
+        W, X = build_sensing_matrix(samples, preconditioning)
+
+        N = W.shape[0]
+
+        Y = activation(X @ features)
+        try:
+            F = reconstruct(X, W, Y, l=l)
+        except np.linalg.LinAlgError:
+            print("error reconstruction")
+            return None, None
+
+        # energies = sorted(list(compute_energies(F, rho).items()))
+        # energies = np.asarray([e for l, e in energies])
+        # print("Energies: ", energies)
+
+        errors = []
+
+        # for g in G.testing_elements(3):
+        for _ in range(400):
+            g = G.sample()
+            Yg = activation(X @ rho(g) @ features)
+
+            try:
+                Fg = reconstruct(X, W, Yg, l=l)
+            except np.linalg.LinAlgError:
+                errors.append(float("inf"))
+                print("skip element")
+                continue
+
+            gF = rho(g) @ F
+
+            error = np.linalg.norm(gF - Fg, axis=-1)
+            error /= np.linalg.norm(gF, axis=-1)
+            errors.append(error)
+        errors = np.concatenate(errors)
+        assert len(errors.shape) == 1
+        return N, errors
+
+    np.set_printoptions(precision=3, suppress=True, linewidth=10000)
+    N, error = evaluate_samples(sampler, preconditioning, activation, l=regularization)
+
+    if N is not None:
+        return N, error
+    else:
+        return None, None
+
+
+def test_so2_leakyrelu():
+    G = SO2(3)
+
+    L = 3
+
+    irreps = directsum([G.irrep(l) for l in range(L + 1)])
+
+    kernel = np.zeros((irreps.size, 1))
+    kernel[0] = 1.0
+    kernel[1::2] = 1.0
+
+    for n in range(irreps.size, 2 * irreps.size + 1, max(1, irreps.size // 10)):
+        check_reconstruction(
+            irreps,
+            kernel,
+            # sampler=_uniform_sampling(n, G),
+            sampler=_regular_sampling(n, G),
+            preconditioning=preconditioning_so3("uniform"),
+            activation=activation("leakyrelu"),
+            regularization=0.0,
+        )
+
+
+def test_so3_leakyrelu():
+    G = SO3(3)
+
+    L = 2
+
+    irreps = G.bl_regular_representation(L)
+
+    kernel = kernel_so3(L, "P", r=0.9)
+    # kernel = kernel_so3(L, 'dirac')
+
+    print(irreps.size)
+    for n in range(irreps.size, 2 * irreps.size + 15, max(1, irreps.size // 10)):
+        # for solid in ['tetra', 'cube', 'ico']:
+        # for n in range(6, 13):
+        check_reconstruction(
+            irreps,
+            kernel,
+            sampler=_uniform_sampling(n, G),
+            # sampler=_so3_platonic_sampling(solid),
+            # sampler=_regular_sampling(n, G),
+            # sampler=_so3_hopf_sampling(n),
+            # sampler=_so3_sensing_sampling(n),
+            preconditioning=preconditioning_so3("uniform"),
+            activation=activation("leakyrelu"),
+            regularization=1e-9,
+        )
+
+
+# %%
+import matplotlib.pyplot as plt
+
+
+def plot_errs(ax, errs, label):
+    l = ax.plot(errs[:, 0], errs[:, 1], label=label)
+    color = l[0].get_color()
+    ax.fill_between(
+        errs[:, 0],
+        errs[:, 1] - errs[:, 2],
+        errs[:, 1] + errs[:, 2],
+        label=None,
+        color=color,
+        alpha=0.2,
+    )
+
+
+# %%
+
+
+def compute_error(kernel, L, act="leakyrelu", tag=""):
+    G = SO3(3)
+
+    irreps = G.bl_regular_representation(L)
+
+    errs = []
+    print("{0:4s}:\t {1:7s} +- {2:6s}\t{3}".format("nerr", "mean", "stderr", tag))
+    # for n in range(irreps.size, int(1.5 * irreps.size) + 1, max(1, irreps.size // 20)):
+    for solid in ["tetra", "cube", "ico"]:
+        e = []
+        for _ in range(20):
+            N, errors = check_reconstruction(
+                irreps,
+                kernel,
+                samples=10,
+                # sampler=_uniform_sampling(n, G),
+                sampler=_so3_platonic_sampling(solid),
+                # sampler=_regular_sampling(n, G),
+                # sampler=_so3_sensing_sampling(n),
+                preconditioning=preconditioning_so3("uniform"),
+                activation=activation(act),
+                regularization=1e-8,
+            )
+            e.append(errors)
+        e = np.stack(e)
+        m = e.mean()
+        s = e.std()
+        print(f"{N:4.0f}:\t {m:.5f} +- {s:.5f}")
+        errs.append((N, m, s))
+
+    errs = np.asarray(errs)
+    return errs
+
+
+def main():
+    L = 2
+    kernel = kernel_so3(L, "dirac")
+    errs_delta = compute_error(kernel, L, tag=f"SO3({L}), dirac, leakyrelu")
+
+    kernel = kernel_so3(L, "P", r=0.7)
+    errs_P = compute_error(kernel, L, tag=f"SO3({L}), P(r=.7), leakyrelu")
+
+    fig, ax = plt.subplots()
+    plot_errs(ax, errs_delta, r"$\delta$ + SIN")
+    plot_errs(ax, errs_P, r"$P$ + SIN")
+
+    plt.legend()
+    plt.ylim(0.0, errs_delta[:, 1].max() * 1.1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I am suggesting to add the leakyReLU activation. For this, I created an autonomous module in `escnn/nn/modules/nonlinearities` and created a test suite adapted from [test/nn/test_fourier_relu.py](https://github.com/QUVA-Lab/escnn/blob/93146fb23c1b31cc130e2aecad8090589219f9f8/test/nn/test_fourier_relu.py). For the latter, I wasn't sure what all the tests and some of the code in "main" was all about, so I just copied it and changed as little as possible.