### PR TITLE
Switch to a `lie_learn` fork that can be installed easily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     "torch>=1.3",
     "numpy",
     "scipy",
-    "lie_learn",
+    "lie_learn @ git+https://github.com/kalekundert/lie_learn@8f89f11bb0152f4ca694a72256afcedd468bade7",
     "joblib",
     "pymanopt",
     "autograd",


### PR DESCRIPTION
See the discussion in #80 for more information.  Briefly, trying to install the `lie_learn` dependency is a huge pain point right now.  About a month ago, I submitted a PR to `lie_learn` that would fix all the installation issues, but so far it hasn't been merged.  In the interest of solving the issue for `escnn` users in the meantime, this PR redirects the `lie_learn` dependency to my fork (which adds just a single commit).