### PR TITLE
Generalize the Fourier transform API

### DIFF
--- a/escnn/nn/__init__.py
+++ b/escnn/nn/__init__.py
@@ -1,16 +1,17 @@
 
-from .field_type import FieldType
+from .field_type import FieldType, FourierFieldType
 from .geometric_tensor import GeometricTensor, tensor_directsum
+from .grid_tensor import GridTensor
 
 from .modules import *
 from .modules import __all__ as modules_list
 
 __all__ = [
     "FieldType",
+    "FourierFieldType",
     "GeometricTensor",
+    "GridTensor",
     "tensor_directsum",
-    # Modules
-] + modules_list + [
-    # init
+    *modules_list,
     "init",
 ]

--- a/escnn/nn/grid_tensor.py
+++ b/escnn/nn/grid_tensor.py
@@ -1,0 +1,6 @@
+class GridTensor:
+
+    def __init__(self, tensor, grid, coords):
+        self.tensor = tensor
+        self.grid = grid
+        self.coords = coords

--- a/escnn/nn/modules/__init__.py
+++ b/escnn/nn/modules/__init__.py
@@ -23,6 +23,8 @@ except ImportError:
 
 from .linear import Linear
 
+from .fourier import FourierTransform, InverseFourierTransform
+
 from .nonlinearities import GatedNonLinearity1
 from .nonlinearities import GatedNonLinearity2
 from .nonlinearities import GatedNonLinearityUniform
@@ -90,7 +92,7 @@ __all__ = [
     "MergeModule",
     "MultipleModule",
     "Linear",
-] + _point_conv_modules + [
+    *_point_conv_modules,
     "R3Conv",
     "R2Conv",
     "R2ConvTransposed",
@@ -150,4 +152,6 @@ __all__ = [
     "IdentityModule",
     "MaskModule",
     "HarmonicPolynomialR3",
+    "FourierTransform",
+    "InverseFourierTransform",
 ]

--- a/escnn/nn/modules/fourier.py
+++ b/escnn/nn/modules/fourier.py
@@ -1,0 +1,160 @@
+import numpy as np
+import torch
+
+from escnn.nn import FourierFieldType, GeometricTensor, GridTensor
+from escnn.nn.field_type import make_fourier_representation
+from escnn.group import Group, GroupElement
+from torch.nn import Module
+
+from typing import Sequence, Optional
+
+__all__ = ['FourierTransform', 'InverseFourierTransform']
+
+# Docs:
+# - Low level class, meant for building other modules
+# - If use directly, possible to break equivariance
+
+class InverseFourierTransform(Module):
+
+    def __init__(
+            self,
+            in_type: FourierFieldType,
+            out_grid: Sequence[GroupElement],
+            *,
+            normalize: bool = True,
+    ):
+        super().__init__()
+
+        assert isinstance(in_type, FourierFieldType)
+
+        self.in_type = in_type
+        self.out_grid = list(out_grid)
+
+        A = _build_ift(in_type, out_grid, normalize)
+        A = torch.tensor(A, dtype=torch.get_default_dtype())
+
+        self.register_buffer('A', A)
+
+    def forward(self, input: GeometricTensor) -> GridTensor:
+        assert input.type == self.in_type
+        
+        x_hat = input.tensor.view(
+                input.shape[0],
+                self.in_type.channels,
+                self.in_type.rho.size,
+                *input.shape[2:],
+        )
+
+        x = torch.einsum('bcf...,gf->bcg...', x_hat, self.A)
+
+        return GridTensor(x, self.out_grid, input.coords)
+
+class FourierTransform(Module):
+
+    def __init__(
+            self,
+            in_grid,
+            out_type,
+            *,
+            extra_irreps: Optional[list] = None,
+            normalize: bool = True,
+    ):
+        super().__init__()
+
+        assert isinstance(out_type, FourierFieldType)
+
+        self.in_grid = in_grid
+        self.out_type = out_type
+
+        if extra_irreps is None:
+            ift_type = out_type
+        else:
+            extra_irreps = [
+                    x
+                    for x in extra_irreps
+                    if x not in out_type.bl_irreps
+            ]
+            ift_type = FourierFieldType(
+                    out_type.gspace,
+                    out_type.channels,
+                    out_type.bl_irreps + extra_irreps,
+                    subgroup_id=out_type.subgroup_id,
+            )
+
+        A = _build_ift(ift_type, in_grid, normalize)
+
+        eps = 1e-8
+        n = ift_type.rho.size
+        Ainv = np.linalg.inv(A.T @ A + eps * np.eye(n)) @ A.T
+
+        if extra_irreps is not None:
+            Ainv = Ainv[:out_type.rho.size, :]
+
+        Ainv = torch.tensor(Ainv, dtype=torch.get_default_dtype())
+        
+        self.register_buffer('Ainv', Ainv)
+
+    def forward(self, input: GridTensor) -> GeometricTensor:
+        assert input.grid == self.in_grid
+
+        y = input.tensor
+
+        y_hat = torch.einsum('bcg...,fg->bcf...', y, self.Ainv)
+
+        y_hat = y_hat.reshape(y.shape[0], self.out_type.size, *y.shape[3:])
+
+        return GeometricTensor(y_hat, self.out_type, input.coords)
+
+
+def _build_ift(in_type: FourierFieldType, out_grid, normalize: bool):
+    """
+    Create a matrix that will apply an inverse Fourier transform to a feature 
+    vector of the given *in_type*.
+    """
+    assert isinstance(in_type, FourierFieldType)
+
+    G = in_type.fibergroup
+
+    if in_type.subgroup_id is None:
+        kernel = _build_regular_kernel(G, in_type.bl_irreps)
+    else:
+        kernel = _build_quotient_kernel(G, in_type.subgroup_id, in_type.bl_irreps)
+
+    assert kernel.shape[0] == in_type.rho.size
+
+    if normalize:
+        kernel = kernel / np.linalg.norm(kernel)
+
+    kernel = kernel.reshape(-1, 1)
+    
+    return np.concatenate(
+        [
+            in_type.rho(g) @ kernel
+            for g in out_grid
+        ], axis=1
+    ).T
+
+def _build_regular_kernel(G: Group, irreps: list[tuple]):
+    kernel = []
+    
+    for irr in irreps:
+        irr = G.irrep(*irr)
+        
+        c = int(irr.size//irr.sum_of_squares_constituents)
+        k = irr(G.identity)[:, :c] * np.sqrt(irr.size)
+        kernel.append(k.T.reshape(-1))
+    
+    kernel = np.concatenate(kernel)
+    return kernel
+
+def _build_quotient_kernel(G: Group, subgroup_id: tuple, irreps: list[tuple]):
+    kernel = []
+    
+    X: HomSpace = G.homspace(subgroup_id)
+    
+    for irr in irreps:
+        k = X._dirac_kernel_ft(irr, X.H.trivial_representation.id)
+        kernel.append(k.T.reshape(-1))
+    
+    kernel = np.concatenate(kernel)
+    return kernel

--- a/escnn/nn/modules/nonlinearities/fourier.py
+++ b/escnn/nn/modules/nonlinearities/fourier.py
@@ -1,53 +1,28 @@
 
 from escnn.group import *
 from escnn.gspaces import *
-from escnn.nn import FieldType
-from escnn.nn import GeometricTensor
+from escnn.nn import FourierFieldType, GeometricTensor
 
 from ..equivariant_module import EquivariantModule
+from ..fourier import InverseFourierTransform, FourierTransform
 
 import torch
 import torch.nn.functional as F
 
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Optional
 
 import numpy as np
 
 __all__ = ["FourierPointwise", "FourierELU"]
 
 
-def _build_kernel(G: Group, irrep: List[tuple]):
-    kernel = []
-    
-    for irr in irrep:
-        irr = G.irrep(*irr)
-        
-        c = int(irr.size//irr.sum_of_squares_constituents)
-        k = irr(G.identity)[:, :c] * np.sqrt(irr.size)
-        kernel.append(k.T.reshape(-1))
-    
-    kernel = np.concatenate(kernel)
-    return kernel
-    
-
 class FourierPointwise(EquivariantModule):
     
-    def __init__(
-            self,
-            gspace: GSpace,
-            channels: int,
-            irreps: List,
-            *grid_args,
-            function: str = 'p_relu',
-            inplace: bool = True,
-            out_irreps: List = None,
-            normalize: bool = True,
-            **grid_kwargs
-    ):
+    def __init__(self, *args, **kwargs):
         r"""
         
-        Applies a Inverse Fourier Transform to sample the input features, apply the pointwise non-linearity in the
-        group domain (Dirac-delta basis) and, finally, computes the Fourier Transform to obtain irreps coefficients.
+        Perform an Inverse Fourier Transform to sample the input features, apply the pointwise non-linearity in the
+        group domain (Dirac-delta basis) and, finally, compute the Fourier Transform to obtain irreps coefficients.
         
         .. warning::
             This operation is only *approximately* equivariant and its equivariance depends on the sampling grid and the
@@ -56,7 +31,7 @@ class FourierPointwise(EquivariantModule):
         The same function is applied to every channel independently.
         By default, the input representation is preserved by this operation and, therefore, it equals the output
         representation.
-        Optionally, the output can have a different band-limit by using the argument ``out_irreps``.
+        Optionally, the output can have a different band-limit by using the argument ``out_type``.
         
         The class first constructs a band-limited regular representation of ```gspace.fibergroup``` using
         :meth:`escnn.group.Group.spectral_regular_representation`.
@@ -72,8 +47,8 @@ class FourierPointwise(EquivariantModule):
             used to generate this list with through a simpler interface. Check each group's documentation.
         
         To approximate the Fourier transform, this module uses a finite number of samples from the group.
-        The set of samples used is specified by the ```grid_args``` and ```grid_kwargs``` which are forwarded to
-        the method :meth:`~escnn.group.Group.grid`.
+        The set of samples used is specified by the ``grid`` argument.  This can be any list of group elements, but most
+        often the :meth:`~escnn.group.Group.grid` is used to generate this list.
         
         Args:
             gspace (GSpace):  the gspace describing the symmetries of the data. The Fourier transform is
@@ -90,28 +65,29 @@ class FourierPointwise(EquivariantModule):
             **grid_kwargs: keyword parameters used to construct the discretization grid
             
         """
+        super().__init__()
 
-        assert isinstance(gspace, GSpace)
-        
-        super(FourierPointwise, self).__init__()
-
-        self.space = gspace
-        
-        G: Group = gspace.fibergroup
-        
-        self.rho = G.spectral_regular_representation(*irreps, name=None)
-
-        self.in_type = FieldType(self.space, [self.rho] * channels)
-
-        if out_irreps is None:
-            # the representation in input is preserved
-            self.out_type = self.in_type
-            self.rho_out = self.rho
+        if isinstance(args[0], FourierFieldType):
+            self._init(*args, **kwargs)
         else:
-            self.rho_out = G.spectral_regular_representation(*out_irreps, name=None)
-            self.out_type = FieldType(self.space, [self.rho_out] * channels)
+            self._init_deprecated(*args, **kwargs)
 
-        # retrieve the activation function to apply
+    def _init(
+            self,
+            in_type: FourierFieldType,
+            grid: List[GroupElement],
+            function: str = 'p_relu',
+            *,
+            out_type: Optional[FourierFieldType] = None,
+            inplace: bool = True,
+            normalize: bool = True,
+    ):
+        self.in_type = in_type
+        self.out_type = out_type or in_type
+
+        self.ift = InverseFourierTransform(in_type, grid, normalize=normalize)
+        self.ft = FourierTransform(grid, self.out_type, extra_irreps=in_type.bl_irreps, normalize=normalize)
+
         if function == 'p_relu':
             self._function = F.relu_ if inplace else F.relu
         elif function == 'p_elu':
@@ -123,54 +99,36 @@ class FourierPointwise(EquivariantModule):
         else:
             raise ValueError('Function "{}" not recognized!'.format(function))
         
-        kernel = _build_kernel(G, irreps)
-        assert kernel.shape[0] == self.rho.size
+    def _init_deprecated(
+            self,
+            gspace: GSpace,
+            channels: int,
+            irreps: List,
+            *grid_args,
+            grid: List[GroupElement] = None,
+            function: str = 'p_relu',
+            inplace: bool = True,
+            out_irreps: List = None,
+            normalize: bool = True,
+            **grid_kwargs
+    ):
+        from warnings import warn
+        warn("The `gspace`, `channels`, and `irreps` arguments are deprecated.  Use the `in_type` argument instead.", DeprecationWarning)
 
-        if normalize:
-            kernel = kernel / np.linalg.norm(kernel)
-        kernel = kernel.reshape(-1, 1)
+        in_type = FourierFieldType(gspace, channels, irreps)
+        out_type = FourierFieldType(gspace, channels, out_irreps or irreps)
+
+        if grid is None:
+            grid = gspace.fibergroup.grid(*grid_args, **grid_kwargs)
+
+        self._init(
+                in_type, grid, function,
+                out_type=out_type,
+                inplace=inplace,
+                normalize=normalize,
+        )
         
-        grid = G.grid(*grid_args, **grid_kwargs)
-        
-        A = np.concatenate(
-            [
-                self.rho(g) @ kernel
-                for g in grid
-            ], axis=1
-        ).T
-
-        if out_irreps is not None:
-
-            _missing_input_irreps = list(set(irreps).difference(set(out_irreps)))
-            rho_out_extended = G.spectral_regular_representation(*out_irreps, *_missing_input_irreps, name=None)
-            kernel_out = _build_kernel(G, out_irreps + _missing_input_irreps)
-            assert kernel_out.shape[0] == rho_out_extended.size
-
-            if normalize:
-                kernel_out = kernel_out / np.linalg.norm(kernel_out)
-            kernel_out = kernel_out.reshape(-1, 1)
-
-            A_out = np.concatenate(
-                [
-                    rho_out_extended(g) @ kernel_out
-                    for g in grid
-                ], axis=1
-            ).T
-        else:
-            A_out = A
-            _missing_input_irreps = []
-            rho_out_extended = self.rho_out
-
-        eps = 1e-8
-        Ainv = np.linalg.inv(A_out.T @ A_out + eps * np.eye(rho_out_extended.size)) @ A_out.T
-
-        if out_irreps is not None:
-            Ainv = Ainv[:self.rho_out.size, :]
-
-        self.register_buffer('A', torch.tensor(A, dtype=torch.get_default_dtype()))
-        self.register_buffer('Ainv', torch.tensor(Ainv, dtype=torch.get_default_dtype()))
-        
-    def forward(self, input: GeometricTensor) -> GeometricTensor:
+    def forward(self, x_hat: GeometricTensor) -> GeometricTensor:
         r"""
 
         Applies the pointwise activation function on the input fields
@@ -183,20 +141,13 @@ class FourierPointwise(EquivariantModule):
 
         """
 
-        assert input.type == self.in_type
-        
-        shape = input.shape
-        x_hat = input.tensor.view(shape[0], len(self.in_type), self.rho.size, *shape[2:])
-        
-        x = torch.einsum('bcf...,gf->bcg...', x_hat, self.A)
-        
-        y = self._function(x)
+        assert x_hat.type == self.in_type
 
-        y_hat = torch.einsum('bcg...,fg->bcf...', y, self.Ainv)
+        x = self.ift(x_hat)
 
-        y_hat = y_hat.reshape(shape[0], self.out_type.size, *shape[2:])
+        x.tensor = self._function(x.tensor)
 
-        return GeometricTensor(y_hat, self.out_type, input.coords)
+        return self.ft(x)
 
     def evaluate_output_shape(self, input_shape: Tuple[int, ...]) -> Tuple[int, ...]:
 
@@ -210,29 +161,33 @@ class FourierPointwise(EquivariantModule):
 
     def check_equivariance(self, atol: float = 1e-5, rtol: float = 2e-2, assert_raise: bool = True) -> List[Tuple[Any, float]]:
     
+        gspace = self.in_type.gspace
+        rho = self.in_type.rho
+        rho_out = self.out_type.rho
         c = self.in_type.size
         B = 128
-        x = torch.randn(B, c, *[3]*self.space.dimensionality)
+        x = torch.randn(B, c, *[3]*gspace.dimensionality)
 
-        # since we mostly use non-linearities like relu or elu, we make sure the average value of the features is
+        # since we mostly use non-linearities like relu or elu, we make sure 
+        # the average value of the features is
         # positive, such that, when we test inputs with only frequency 0 (or only low frequencies), the output is not
         # zero everywhere
-        x = x.view(B, len(self.in_type), self.rho.size, *[3]*self.space.dimensionality)
+        x = x.view(B, len(self.in_type), rho.size, *[3]*gspace.dimensionality)
         p = 0
-        for irr in self.rho.irreps:
-            irr = self.space.irrep(*irr)
+        for irr in rho.irreps:
+            irr = gspace.irrep(*irr)
             if irr.is_trivial():
                 x[:, :, p] = x[:, :, p].abs()
             p+=irr.size
 
-        x = x.view(B, self.in_type.size, *[3]*self.space.dimensionality)
+        x = x.view(B, self.in_type.size, *[3]*gspace.dimensionality)
 
         errors = []
 
-        # for el in self.space.testing_elements:
+        # for el in gspace.testing_elements:
         for _ in range(100):
             
-            el = self.space.fibergroup.sample()
+            el = gspace.fibergroup.sample()
     
             x1 = GeometricTensor(x.clone(), self.in_type)
             x2 = GeometricTensor(x.clone(), self.in_type).transform_fibers(el)
@@ -240,8 +195,8 @@ class FourierPointwise(EquivariantModule):
             out1 = self(x1).transform_fibers(el)
             out2 = self(x2)
 
-            out1 = out1.tensor.view(B, len(self.out_type), self.rho_out.size, *out1.shape[2:]).detach().numpy()
-            out2 = out2.tensor.view(B, len(self.out_type), self.rho_out.size, *out2.shape[2:]).detach().numpy()
+            out1 = out1.tensor.view(B, len(self.out_type), rho_out.size, *out1.shape[2:]).detach().numpy()
+            out2 = out2.tensor.view(B, len(self.out_type), rho_out.size, *out2.shape[2:]).detach().numpy()
 
             errs = np.linalg.norm(out1 - out2, axis=2).reshape(-1)
             errs[errs < atol] = 0.
@@ -262,14 +217,24 @@ class FourierPointwise(EquivariantModule):
         # return errors
         return np.concatenate(errors).reshape(-1)
 
+    # The following properties are just for backwards compatibility
+    @property
+    def space(self):
+        return self.in_type.gspace
+
+    @property
+    def rho(self):
+        return self.in_type.rho
+    
+    @property
+    def rho_out(self):
+        return self.out_type.rho
+    
+
 
 class FourierELU(FourierPointwise):
     
-    def __init__(
-            self,
-            gspace: GSpace, channels: int, irreps: List, *grid_args,
-            inplace: bool = True, out_irreps: List = None, normalize: bool = True,  **grid_kwargs
-    ):
+    def __init__(self, *args, **kwargs):
         r"""
 
         Applies a Inverse Fourier Transform to sample the input features, apply ELU point-wise in the
@@ -289,7 +254,6 @@ class FourierELU(FourierPointwise):
 
         """
         
-        super(FourierELU, self).__init__(
-            gspace, channels, irreps, *grid_args,
-            function='p_elu', inplace=inplace, out_irreps=out_irreps, normalize=normalize, **grid_kwargs)
+        kwargs['function'] = 'p_elu'
+        super().__init__(*args, **kwargs)
 

--- a/escnn/nn/modules/nonlinearities/fourier_quotient.py
+++ b/escnn/nn/modules/nonlinearities/fourier_quotient.py
@@ -1,56 +1,38 @@
 
 from escnn.group import *
 from escnn.gspaces import *
-from escnn.nn import FieldType
+from escnn.nn import FourierFieldType
 from escnn.nn import GeometricTensor
 
-from ..equivariant_module import EquivariantModule
-
-import torch
-import torch.nn.functional as F
+from .fourier import FourierPointwise
 
 from typing import List, Tuple, Any
-
-import numpy as np
 
 __all__ = ["QuotientFourierPointwise", "QuotientFourierELU"]
 
 
-def _build_kernel(G: Group, subgroup_id: Tuple, irrep: List[tuple]):
-    kernel = []
+class QuotientFourierPointwise(FourierPointwise):
     
-    X: HomSpace = G.homspace(subgroup_id)
-    
-    for irr in irrep:
-        k = X._dirac_kernel_ft(irr, X.H.trivial_representation.id)
-        # irr = G.irrep(*irr)
-        # K *= np.sqrt(irr.size)
-        kernel.append(k.T.reshape(-1))
-    
-    kernel = np.concatenate(kernel)
-    return kernel
-    
-
-class QuotientFourierPointwise(EquivariantModule):
-    
-    def __init__(self,
-                 gspace: GSpace,
-                 subgroup_id: Tuple,
-                 channels: int,
-                 irreps: List,
-                 *grid_args,
-                 grid: List[GroupElement] = None,
-                 function: str = 'p_relu',
-                 inplace: bool=True,
-                 out_irreps: List = None,
-                 normalize: bool = True,
-                 **grid_kwargs
-                 ):
+    def __init__(
+            self,
+            gspace: GSpace,
+            subgroup_id: Tuple,
+            channels: int,
+            irreps: List,
+            *grid_args,
+            grid: List[GroupElement] = None,
+            function: str = 'p_relu',
+            inplace: bool = True,
+            out_irreps: List = None,
+            normalize: bool = True,
+            **grid_kwargs
+    ):
         r"""
-        
-        Applies a Inverse Fourier Transform to sample the input features on a *quotient space* :math:`X`, apply the
-        pointwise non-linearity in the spatial domain (Dirac-delta basis) and, finally, computes the Fourier Transform
+
+        Perform an Inverse Fourier Transform to sample the input features on a *quotient space* :math:`X`, apply the
+        pointwise non-linearity in the spatial domain (Dirac-delta basis) and, finally, compute the Fourier Transform
         to obtain irreps coefficients.
+
         The quotient space used is isomorphic to :math:`X \cong G / H` where :math:`G` is ```gspace.fibergroup``` while
         :math:`H` is the subgroup of :math:`G` idenitified by ```subgroup_id```; see
         :meth:`~escnn.group.Group.subgroup` and :meth:`~escnn.group.Group.homspace`
@@ -111,177 +93,27 @@ class QuotientFourierPointwise(EquivariantModule):
             **grid_kwargs: keyword parameters used to construct the discretization grid
             
         """
+        from warnings import warn
+        warn("The `QuotientFourierPointwise` module is deprecated.  Instead, create a \"quotient\" field type by passing the `subgroup_id` argument to `FourierFieldType`, then use `FourierPointwise` on that field.", DeprecationWarning)
 
-        assert isinstance(gspace, GSpace)
-        
-        super(QuotientFourierPointwise, self).__init__()
+        in_type = FourierFieldType(
+                gspace, channels, irreps,
+                subgroup_id=subgroup_id,
+        )
+        out_type = FourierFieldType(
+                gspace, channels, out_irreps or irreps,
+                subgroup_id=subgroup_id,
+        )
 
-        self.space = gspace
-        
-        G: Group = gspace.fibergroup
-        
-        self.rho = G.spectral_quotient_representation(subgroup_id, *irreps, name=None)
-
-        self.in_type = FieldType(self.space, [self.rho]*channels)
-
-        if out_irreps is None:
-            # the representation in input is preserved
-            self.out_type = self.in_type
-            self.rho_out = self.rho
-        else:
-            self.rho_out = G.spectral_quotient_representation(subgroup_id, *out_irreps, name=None)
-            self.out_type = FieldType(self.space, [self.rho_out] * channels)
-
-        # retrieve the activation function to apply
-        if function == 'p_relu':
-            self._function = F.relu_ if inplace else F.relu
-        elif function == 'p_elu':
-            self._function = F.elu_ if inplace else F.elu
-        elif function == 'p_sigmoid':
-            self._function = torch.sigmoid_ if inplace else F.sigmoid
-        elif function == 'p_tanh':
-            self._function = torch.tanh_ if inplace else F.tanh
-        else:
-            raise ValueError('Function "{}" not recognized!'.format(function))
-        
-        kernel = _build_kernel(G, subgroup_id, irreps)
-        assert kernel.shape[0] == self.rho.size
-
-        if normalize:
-            kernel = kernel / np.linalg.norm(kernel)
-        kernel = kernel.reshape(-1, 1)
-        
         if grid is None:
-            grid = G.grid(*grid_args, **grid_kwargs)
-        
-        A = np.concatenate(
-            [
-                self.rho(g) @ kernel
-                for g in grid
-            ], axis=1
-        ).T
+            grid = gspace.fibergroup.grid(*grid_args, **grid_kwargs)
 
-        if out_irreps is not None:
-
-            _missing_input_irreps = list(set(irreps).difference(set(out_irreps)))
-            # _missing_input_irreps = []
-            rho_out_extended = G.spectral_quotient_representation(subgroup_id, *out_irreps, *_missing_input_irreps, name=None)
-            kernel_out = _build_kernel(G, subgroup_id, out_irreps + _missing_input_irreps)
-            assert kernel_out.shape[0] == rho_out_extended.size
-
-            if normalize:
-                kernel_out = kernel_out / np.linalg.norm(kernel_out)
-            kernel_out = kernel_out.reshape(-1, 1)
-
-            A_out = np.concatenate(
-                [
-                    rho_out_extended(g) @ kernel_out
-                    for g in grid
-                ], axis=1
-            ).T
-        else:
-            A_out = A
-            _missing_input_irreps = []
-            rho_out_extended = self.rho_out
-
-        eps = 1e-8
-        Ainv = np.linalg.inv(A_out.T @ A_out + eps * np.eye(rho_out_extended.size)) @ A_out.T
-
-        if out_irreps is not None:
-            Ainv = Ainv[:self.rho_out.size, :]
-
-        self.register_buffer('A', torch.tensor(A, dtype=torch.get_default_dtype()))
-        self.register_buffer('Ainv', torch.tensor(Ainv, dtype=torch.get_default_dtype()))
-        
-    def forward(self, input: GeometricTensor) -> GeometricTensor:
-        r"""
-
-        Applies the pointwise activation function on the input fields
-
-        Args:
-            input (GeometricTensor): the input feature map
-
-        Returns:
-            the resulting feature map after the non-linearities have been applied
-
-        """
-
-        assert input.type == self.in_type
-        
-        shape = input.shape
-        x_hat = input.tensor.view(shape[0], len(self.in_type), self.rho.size, *shape[2:])
-        
-        x = torch.einsum('bcf...,gf->bcg...', x_hat, self.A)
-        
-        y = self._function(x)
-
-        y_hat = torch.einsum('bcg...,fg->bcf...', y, self.Ainv)
-
-        y_hat = y_hat.reshape(shape[0], self.out_type.size, *shape[2:])
-
-        return GeometricTensor(y_hat, self.out_type, input.coords)
-
-    def evaluate_output_shape(self, input_shape: Tuple[int, ...]) -> Tuple[int, ...]:
-
-        assert len(input_shape) >= 2
-        assert input_shape[1] == self.in_type.size
-
-        b, c = input_shape[:2]
-        spatial_shape = input_shape[2:]
-
-        return (b, self.out_type.size, *spatial_shape)
-
-    def check_equivariance(self, atol: float = 1e-5, rtol: float = 2e-2, assert_raise: bool = True) -> List[Tuple[Any, float]]:
-    
-        c = self.in_type.size
-        B = 64
-        x = torch.randn(B, c, *[3]*self.space.dimensionality)
-
-        # since we mostly use non-linearities like relu or elu, we make sure the average value of the features is
-        # positive, such that, when we test inputs with only frequency 0 (or only low frequencies), the output is not
-        # zero everywhere
-        x = x.view(B, len(self.in_type), self.rho.size, *[3]*self.space.dimensionality)
-        p = 0
-        for irr in self.rho.irreps:
-            irr = self.space.irrep(*irr)
-            if irr.is_trivial():
-                x[:, :, p] = x[:, :, p].abs()
-            p+=irr.size
-        x = x.view(B, self.in_type.size, *[3]*self.space.dimensionality)
-
-        errors = []
-    
-        # for el in self.space.testing_elements:
-        for _ in range(100):
-            
-            el = self.space.fibergroup.sample()
-    
-            x1 = GeometricTensor(x.clone(), self.in_type)
-            x2 = GeometricTensor(x.clone(), self.in_type).transform_fibers(el)
-
-            out1 = self(x1).transform_fibers(el)
-            out2 = self(x2)
-            
-            out1 = out1.tensor.view(B, len(self.out_type), self.rho_out.size, *out1.shape[2:]).detach().numpy()
-            out2 = out2.tensor.view(B, len(self.out_type), self.rho_out.size, *out2.shape[2:]).detach().numpy()
-
-            errs = np.linalg.norm(out1 - out2, axis=2).reshape(-1)
-            errs[errs < atol] = 0.
-            norm = np.sqrt(np.linalg.norm(out1, axis=2).reshape(-1) * np.linalg.norm(out2, axis=2).reshape(-1))
-            
-            relerr = errs / norm
-            
-            # print(el, errs.max(), errs.mean(), relerr.max(), relerr.min())
-            if assert_raise:
-                assert relerr.mean()+ relerr.std() < rtol, \
-                    'The error found during equivariance check with element "{}" is too high: max = {}, mean = {}, std ={}, maxerr={}, xmean={}, xstd={}' \
-                        .format(el, relerr.max(), relerr.mean(), relerr.std(), errs[np.argmax(relerr)], out1.mean(), out1.std())
-        
-            # errors.append((el, errs.mean()))
-            errors.append(relerr)
-
-        # return errors
-        return np.concatenate(errors)
+        super().__init__(
+                in_type, grid, function,
+                out_type=out_type,
+                inplace=inplace,
+                normalize=normalize,
+        )
 
 
 class QuotientFourierELU(QuotientFourierPointwise):


### PR DESCRIPTION
This PR is a proposal to refactor the Fourier transform API, with the goal of making it easier to incorporate Fourier transforms into other modules.  Here are the two specific use-cases I was trying to facilitate:

- A Fourier max pooling layer, as discussed in #65.  This would be very similar to the existing `FourierPointwise` class, except after the nonlinearity, there would also be max-pooling and Gaussian blurring steps.

- An IFT as an output layer.  It's probably not clear what I mean by that, and it's possible that I only needed such a layer because I overlooked some easier way of doing things, so I want to take some time to explain the problem I was trying to solve.  My goal was to reimplement [[Doersch2016]](http://arxiv.org/abs/1505.05192), but in 3D and with equivariance.  The idea in [Doersch2016] is to create a self-supervised training protocol by taking two nearby crops of an image, and having the model predict the location of the second relative to the first.  There would only be a handful of possible relative locations, e.g. above, below, right, and left (for 2D images).  I implemented this by having the final layer of my model be a single spectral regular representation (of the quotient space $S^2 = SO(3) / SO(2)$, because the two crops cannot rotate relative to each other), then performing an IFT with each grid point corresponding to one of the possible relative locations.  This results in values for each location that can be interpreted as logits.  And if the input rotates, so do the logits.  To bring this back to the PR at hand, the important point is that this application requires being able to perform an IFT without a subsequent FT.

I think that the best way to support these two use-cases, and possibly others that I haven't thought of, is to create separate FT and IFT modules.  That's what the proposed API does.  Here are the specific classes involved:

- `InverseFourierTransform`: A pytorch module where the input is a tensor with a spectral regular representation, and the output is a tensor of signal values sampled on a grid.

- `FourierTransform`: The opposite of `InverseFourierTransform`.  This module also provides the option to prepare the FT matrix with more irreps than will ultimately be output.

- `FourierFieldType`: Most equivariant modules accept input/output field types as arguments, but `FourierPointwise` is an exception.  It accepts `gspace`, `channels`, and `irreps` arguments, and uses them to create a compatible field type under the hood.  This API is a bit awkward to begin with, but it's worse when the same arguments need to be passed to two different modules.

  To bring the Fourier API in line with all the other modules, I created `FourierFieldType`.  This is a subclass of `FieldType` that only allows spectral regular representations (possibly with respect to a quotient space).  The IFT and FT modules require this field type (and check for it).  Other modules are agnostic to it.

- `GridTensor`: A class that wraps the output of an IFT and the input to an FT.  It's similar in concept to `GeometricTensor`, except that instead of keeping track of the representation associated with a tensor, it keeps track of the grid.  This lets the FT module check that it's compatible with the input it receives, and (for GNNs) restore the `coords` attribute.

Using these classes, I reimplemented the `FourierPointwise` class in a way that I believe to be 100% backwards-compatible.  The new implementation also removes hundreds of lines of code that were duplicated between `FourierPointwise` and `QuotientFourierPointwise`.  Below is a simplified `FourierRelu` version of this class, just to give a sense for how it works:

```python
class FourierRelu(EquivariantModule):
    
    def __init__(self, in_type: FourierFieldType, grid: List[GroupElement]):
        super().__init__()
        self.in_type = self.out_type = in_type
        self.ift = InverseFourierTransform(self.in_type, grid)
        self.ft = FourierTransform(grid, self.out_type)
        
    def forward(self, x_hat: GeometricTensor) -> GeometricTensor:
        assert x_hat.type == self.in_type
        x: GridTensor = self.ift(x_hat)
        F.relu_(x.tensor)
        return self.ft(x)
```

Minor comments:

- This PR isn't ready to be merged yet.  I haven't updated the documentation, and although all the existing tests pass, I want to write some new tests as well.  But before I spend a lot of time on those tasks, I want to know if there's any interest in merging this.

- I haven't implemented the aforementioned Fourier max pooling module yet.  But if there's interest, I could add that to the PR as well.
