### PR TITLE
Replace `from torch.nn.functional import ...` with `import torch.nn.functional as F`

### DIFF
--- a/escnn/nn/modules/conv/r2_transposed_convolution.py
+++ b/escnn/nn/modules/conv/r2_transposed_convolution.py
@@ -1,5 +1,5 @@
 
-from torch.nn.functional import conv_transpose2d
+import torch.nn.functional as F
 
 import escnn.nn
 from escnn.nn import FieldType
@@ -127,7 +127,7 @@ class R2ConvTransposed(_RdConvTransposed):
             _filter, _bias = self.expand_parameters()
         
         # use it for convolution and return the result
-        output = conv_transpose2d(
+        output = F.conv_transpose2d(
                         input.tensor, _filter,
                         padding=self.padding,
                         output_padding=self.output_padding,

--- a/escnn/nn/modules/conv/r2convolution.py
+++ b/escnn/nn/modules/conv/r2convolution.py
@@ -1,4 +1,4 @@
-from torch.nn.functional import conv2d, pad
+import torch.nn.functional as F
 
 from escnn.nn import FieldType
 from escnn.nn import GeometricTensor
@@ -214,14 +214,14 @@ class R2Conv(_RdConv):
         # use it for convolution and return the result
         
         if self.padding_mode == 'zeros':
-            output = conv2d(input.tensor, _filter,
+            output = F.conv2d(input.tensor, _filter,
                             stride=self.stride,
                             padding=self.padding,
                             dilation=self.dilation,
                             groups=self.groups,
                             bias=_bias)
         else:
-            output = conv2d(pad(input.tensor, self._reversed_padding_repeated_twice, self.padding_mode),
+            output = F.conv2d(F.pad(input.tensor, self._reversed_padding_repeated_twice, self.padding_mode),
                             _filter,
                             stride=self.stride,
                             dilation=self.dilation,

--- a/escnn/nn/modules/conv/r3_transposed_convolution.py
+++ b/escnn/nn/modules/conv/r3_transposed_convolution.py
@@ -1,6 +1,6 @@
 import gc
 
-from torch.nn.functional import conv_transpose3d
+import torch.nn.functional as F
 
 import escnn.nn
 from escnn.nn import FieldType
@@ -128,7 +128,7 @@ class R3ConvTransposed(_RdConvTransposed):
 
 
         # use it for convolution and return the result
-        output = conv_transpose3d(
+        output = F.conv_transpose3d(
                         input.tensor, _filter,
                         padding=self.padding,
                         output_padding=self.output_padding,

--- a/escnn/nn/modules/conv/r3convolution.py
+++ b/escnn/nn/modules/conv/r3convolution.py
@@ -1,4 +1,4 @@
-from torch.nn.functional import conv3d, pad
+import torch.nn.functional as F
 
 import escnn.nn
 from escnn.nn import FieldType
@@ -207,14 +207,14 @@ class R3Conv(_RdConv):
         
         # use it for convolution and return the result
         if self.padding_mode == 'zeros':
-            output = conv3d(input.tensor, _filter,
+            output = F.conv3d(input.tensor, _filter,
                             stride=self.stride,
                             padding=self.padding,
                             dilation=self.dilation,
                             groups=self.groups,
                             bias=_bias)
         else:
-            output = conv3d(pad(input.tensor, self._reversed_padding_repeated_twice, self.padding_mode),
+            output = F.conv3d(F.pad(input.tensor, self._reversed_padding_repeated_twice, self.padding_mode),
                             _filter,
                             stride=self.stride,
                             dilation=self.dilation,

--- a/escnn/nn/modules/linear.py
+++ b/escnn/nn/modules/linear.py
@@ -9,7 +9,7 @@ from escnn.nn.modules.basismanager import BasisManager
 from escnn.nn.modules.basismanager import BlocksBasisExpansion
 
 from torch.nn import Parameter
-from torch.nn.functional import linear
+import torch.nn.functional as F
 import torch
 import numpy as np
 
@@ -202,7 +202,7 @@ class Linear(EquivariantModule):
             # retrieve the matrix and the bias
             _matrix, _bias = self.expand_parameters()
         
-        output = linear(input.tensor, _matrix, bias=_bias)
+        output = F.linear(input.tensor, _matrix, bias=_bias)
         
         return GeometricTensor(output, self.out_type, input.coords)
 

--- a/escnn/nn/modules/nonlinearities/tensor.py
+++ b/escnn/nn/modules/nonlinearities/tensor.py
@@ -12,7 +12,6 @@ from escnn.nn.modules.basismanager import BasisManager
 from escnn.nn.modules.basismanager import BlocksBasisExpansion
 
 from torch.nn import Parameter
-from torch.nn.functional import linear
 
 from typing import List, Tuple, Any
 

--- a/escnn/nn/modules/rdupsampling.py
+++ b/escnn/nn/modules/rdupsampling.py
@@ -15,7 +15,7 @@ import numpy as np
 
 import math
 
-from torch.nn.functional import interpolate
+import torch.nn.functional as F
 
 __all__ = ["R2Upsampling", "R3Upsampling"]
 
@@ -105,12 +105,12 @@ class _RdUpsampling(EquivariantModule, ABC):
         assert len(input.shape) == 2 + self.d, (input.shape, self.d)
 
         if self._align_corners is None:
-            output = interpolate(input.tensor,
+            output = F.interpolate(input.tensor,
                                  size=self._size,
                                  scale_factor=self._scale_factor,
                                  mode=self._mode)
         else:
-            output = interpolate(input.tensor,
+            output = F.interpolate(input.tensor,
                                  size=self._size,
                                  scale_factor=self._scale_factor,
                                  mode=self._mode,


### PR DESCRIPTION
These two expressions are almost identical, but it turns out that the latter is (currently) necessary to visualize models using torchlens. See johnmarktaylor91/torchlens#18 for more information.  While this is a pretty minor benefit, it's also a pretty minor change.