### PR TITLE
Make geometric tensors explicitly not iterable

### DIFF
--- a/escnn/nn/geometric_tensor.py
+++ b/escnn/nn/geometric_tensor.py
@@ -477,6 +477,16 @@ class GeometricTensor:
         tensor = self.tensor.to(*args, **kwargs)
         return GeometricTensor(tensor, self.type, self.coords)
 
+    def __iter__(self):
+        # The purpose of this method is to prevent an infinite loop from 
+        # occurring if a user accidentally tries to iterate over a geometric 
+        # tensor.  The infinite loop occurs because of the way `__getitem__()` 
+        # is implemented [1].
+        #
+        # [1] https://stackoverflow.com/questions/926574/why-does-defining-getitem-on-a-class-make-it-iterable-in-python
+
+        raise TypeError(f"{self.__class__.__name__!r} object is not iterable")
+
     def __getitem__(self, slices) -> 'GeometricTensor':
         r'''
         


### PR DESCRIPTION
Attempting to iterate over a geometric tensor currently results in an infinite loop.  The reason is that python considers an object to be iterable if it implements `__iter__()` or `__getitem__()`.  In the latter case, which is the relevant one for geometric tensors, python iterates by calling `__getitem__(i)` with incrementing values of `i` until an `IndexError` is raised.  `GeometricTensor.__getitem__()` returns an empty tensor instead of raising an `IndexError` for out-of-bounds indices, so the iteration never completes.

I think it's worth getting rid of the infinite loop behavior, because it can be an unpleasant and confusing surprise for users.  There are two ways to do this: (i) don't allow iteration at all, or (ii) mimic the way iteration works for tensors.  My preference is for the former.  For one thing, raising an error now keeps the door open for supporting iteration later, without breaking backwards compatibility.  For another, I don't think that classes should be iterable unless they are truly meant to be containers, and I don't primarily think of tensors as containers.  

